### PR TITLE
Global leak of exchangefile and utilityfile

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,9 +5,9 @@ var XMLHttpRequest = require("xmlhttprequest").XMLHttpRequest;
 
 var currentDirectory = path.dirname(fs.realpathSync(__filename));
 
-exchangefile = fs.readFileSync(path.join(currentDirectory, './exchange-lib/exchange.js'), 'utf8');
+var exchangefile = fs.readFileSync(path.join(currentDirectory, './exchange-lib/exchange.js'), 'utf8');
 eval(exchangefile);
-utilityfile = fs.readFileSync(path.join(currentDirectory, './exchange-lib/utility.js'), 'utf8');
+var utilityfile = fs.readFileSync(path.join(currentDirectory, './exchange-lib/utility.js'), 'utf8');
 eval(utilityfile);
 
 exports.Microsoft = Microsoft;


### PR DESCRIPTION
This variables are global, and should be local. If not, the global variable space of the caller is polluted or overwritten.

I detected this by running the mocha tests of my project with the flag `check-leaks`. Once I added this library, it started failing.

I also checked this by importing this version and running my tests. I mainly use the Contacts and Calendar api and everything works fine with no global variables.
